### PR TITLE
Add SUES UC2-express-bus pinout as a struct

### DIFF
--- a/main/PinConfig.h
+++ b/main/PinConfig.h
@@ -203,6 +203,59 @@ struct UC2_2 : PinConfig
 
 };
 
+struct UC2e : PinConfig
+{
+    String pindefName = "UC2e";
+
+    // UC2e (UC2-express-bus) pinout of the SUES system (modules and baseplane) dictated by the spec for the ESP32 module pinout 
+    // that document maps ESP32 pins to UC2e pins (and pin locations on the physical PCIe x1 connector
+    // and assigns functions compatible with the ESP32 GPIO's hardware capabilities. 
+    // See https://github.com/openUC2/UC2-SUES/blob/main/uc2-express-bus.md#esp32-module-pinout
+    
+    // Stepper Motor control pins
+    int MOTOR_X_DIR = GPIO_NUM_12; // STEP-1_DIR, PP_05, PCIe A8
+    int MOTOR_Y_DIR = GPIO_NUM_13; // STEP-2_DIR, PP_06, PCIe A9
+    int MOTOR_Z_DIR = GPIO_NUM_14; // STEP-3_DIR, PP_07, PCIe A10
+    int MOTOR_A_DIR = GPIO_NUM_15; // STEP-4_DIR, PP_08, PCIe A11
+    int MOTOR_X_STEP = GPIO_NUM_0; // STEP-1_STP, PP_01, PCIe A1 
+    int MOTOR_Y_STEP = GPIO_NUM_2; // STEP-2_STP, PP_02, PCIe A5
+    int MOTOR_Z_STEP = GPIO_NUM_4; // STEP-3_STP, PP_03, PCIe A6
+    int MOTOR_A_STEP = GPIO_NUM_5; // STEP-4_STP, PP_04, PCIe A7
+    int MOTOR_ENABLE = GPIO_NUM_17; // STEP_EN, PP_09, PCIe A13. Enables/disables all stepper drivers' output.
+    bool MOTOR_ENABLE_INVERTED = true; // When set to a logic high, the outputs are disabled.
+    
+    // LED pins (addressable - WS2812 and equivalent)
+    int NEOPIXEL_PIN = GPIO_NUM_18; // NEOPIXEL, PP_10, PCIe A14. I changed the name from LED_PIN to indicate that it's for an adressable LED chain
+    int LED_COUNT = 64; // I havent touched this
+    
+    // Main power switch for all the AUX modules of the baseplane
+    int BASEPLANE_ENABLE = GPIO_NUM_16; // UC2e_EN, ENABLE, PCIe A17. ESP32 module in Controller slot of baseplane switches power off all AUX modules. HIGH activates AUX modules.
+    
+    // Pulse Width Modulation pins
+    int PWM_1 = GPIO_NUM_19; // PWM_1, PP_11, PCIe A16
+    int PWM_2 = GPIO_NUM_23; // PWM_2, PP_12, PCIe B8
+    int PWM_3 = GPIO_NUM_27; // PWM_3, PP_15, PCIe B11
+    int PWM_4 = GPIO_NUM_32; // PWM_4, PP_16, PCIe B12
+    
+    // Digital-to-Analog converter pins
+    int DAC_1 = GPIO_NUM_25; // DAC_1, PP_13, PCIe B9
+    int DAC_2 = GPIO_NUM_27; // DAC_2, PP_14, PCIe B10
+    
+    // Other pins that sense PCIe/housekeeping things
+    int UC2E_OWN_ADDR = GPIO_NUM_33; // Analog input! The voltage indicates into which slot of the baseplane the ESP32 module is plugged.
+    int UC2E_VOLTAGE = GPIO_NUM_34; // Analog input! Can measure the (12V) baseplane power via a voltage divider.
+    
+    // Sensor pins, Analog-to-digital converter enabled
+    int SENSOR_1 = GPIO_NUM_35; // SENSOR_1, PP_17, PCIe B14
+    int SENSOR_1 = GPIO_NUM_36; // SENSOR_2, PP_18, PCIe B15
+    int SENSOR_1 = GPIO_NUM_39; // SENSOR_3, PP_19, PCIe B17
+
+    // I2C pins, digital bus to control various functions of the baseplane and SUES modules
+    int I2C_SDA = GPIO_NUM_21; // I2C_SDA, SDA, PCIe B6
+    int I2C_SCL = GPIO_NUM_22; // I2C_SCL, SCL, PCIe B5
+
+};
+
 struct WEMOS : PinConfig
 {
     String pindefName = "WEMOS";


### PR DESCRIPTION
Maps the desired functionality to ESP32 pins that support it, and those pins have been made a specification for the SUES module-based system. I made some variable names up or changed them. Now all of the GPIOs of the SUES system (see the document linked in the code comment) are in the struct.